### PR TITLE
fix: Update `pyproject.toml` to include the fixtures as a pytest plugin.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pytest-sqlalchemy-mock"
-version = "0.1.6"
+version = "0.1.7"
 license.file = "LICENSE"
 description = "pytest sqlalchemy plugin for mock"
 authors = [
@@ -68,3 +68,6 @@ norecursedirs = [
     ".eggs",
     "venv",
 ]
+
+[project.entry-points."pytest11"]
+pytest_sqlalchemy_mock = "pytest_sqlalchemy_mock.base"


### PR DESCRIPTION
Addresses issue #12.

pytest plugin doc: https://docs.pytest.org/en/latest/how-to/writing_plugins.html#making-your-plugin-installable-by-others